### PR TITLE
Use final URL in History API push instead of requested URL

### DIFF
--- a/src/frontend/js/modules/Navigation.js
+++ b/src/frontend/js/modules/Navigation.js
@@ -217,8 +217,8 @@ class Navigation {
 		return await new Promise((resolve) => {
 			this.worker.addEventListener("message", (event) => {
 				clearTimeout(waiting);
-				// We're only interested in the page body
-				const [body] = event.data;
+				// Get navigation details from Worker
+				const [body, status, finalUrl] = event.data;
 
 				// Update DOM and resolve this and outer Promise
 				this.setTargetHtml(target, body);
@@ -227,7 +227,7 @@ class Navigation {
 				// Target is a valid top navigation, do some stuff
 				if (target === this.main) {
 					// Add loaded URL to history
-					this.historyPush(url);
+					this.historyPush(finalUrl);
 				}
 				
 				resolve(event.data);


### PR DESCRIPTION
Small change to the `history.pushState()` done when a Vegvisir navigation occurs. 

Previously, it would push the requested URL, but with this change it will push the final url (after redirects). Which should encourage users and search engines to use the final URL.