### PR TITLE
Use page index from config in Router request path default

### DIFF
--- a/src/request/Router.php
+++ b/src/request/Router.php
@@ -36,8 +36,8 @@
 		}
 
 		private function get_requested_path(): string {
-			// Requests to root of user content path should be rewritten to /index
-			$path = $this->path !== "/" ? $this->path : "index";
+			// Requests to root of user content path should be rewritten to configured index page
+			$path = $this->path !== "/" ? $this->path : $_ENV[Path::ENV_NS]["page_index"];
 
 			// Strip leading slash
 			if (strpos($this->path, "/") === 0) {


### PR DESCRIPTION
The index page can now be changed in `.env.ini`, so the `get_requested_path()` default value should use that variable too.