### PR TITLE
Added namespaces

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,8 +1,10 @@
 <?php
 
-	require_once "../src/Init.php";
-	require_once Path::vegvisir("src/request/Router.php");
+	use \Vegvisir\Path;
+	use \Vegvisir\Request\Router;
 
-	// Start the request processor. This is how Vegvisir gets initialized
-	// from an HTTP request.
+	require_once "../src/Init.php";
+
+	// Start Vegvisir request processing
+	require_once Path::vegvisir("src/request/Router.php");
 	(new Router());

--- a/src/Init.php
+++ b/src/Init.php
@@ -1,7 +1,61 @@
 <?php
 
+	namespace Vegvisir;
+
+	/*
+		# Vegvisir environment abstractions
+		This class contains abstractions for Vegvisir environment variables
+	*/
+	class ENV {
+        // Vegvisir environment variables are placed in $_ENV as an assoc array with this as the array key.
+        // Example: $_ENV[self::NS][<vegvisir_env_var>]
+        private const NS = "_VEGVISIR";
+
+		// Name of the .ini file containing environment variables to be loaded (internal and userspace)
+		private const INI = ".env.ini";
+
+		// Path to the composer autoload file (internal and userspace)
+		private const COMPOSER_AUTOLOAD = "vendor/autoload.php";
+
+        // Returns true if Reflect environment variable is present and not empty in 
+        public static function isset(string $key): bool {
+            return in_array($key, array_keys($_ENV[self::NS])) && !empty($_ENV[self::NS][$key]);
+        }
+
+		// Get environment variable by key
+		public static function get(string $key): mixed {
+			return self::isset($key) ? $_ENV[self::NS][$key] : null;
+		}
+
+		// Set environment variable key, value pair
+		public static function set(string $key, mixed $value = null) {
+			$_ENV[self::NS][$key] = $value;
+		}
+
+		/* ---- */
+
+		// Load environment variables and dependancies
+		public static function init() {
+			// Put environment variables from Vegvisir .ini into namespaced superglobal
+			$_ENV[self::NS] = parse_ini_file(Path::vegvisir(self::INI), true);
+
+			// Load Composer dependencies
+			require_once Path::vegvisir(self::COMPOSER_AUTOLOAD);
+
+			// Merge environment variables from user site into superglobal
+			if (file_exists(Path::root(self::INI))) {
+				$_ENV = array_merge($_ENV, parse_ini_file(Path::root(self::INI), true));
+			}
+
+			// Load composer dependencies from userspace if exists
+			if (file_exists(Path::root(Path::COMPOSER_AUTOLOAD))) {
+				require_once Path::root(Path::COMPOSER_AUTOLOAD);
+			}
+		}
+    }
+
 	// Global paths
-	final class Path {
+	class Path {
 		// Name of the environment variable files
 		const ENV_INI = ".env.ini";
 		// Namespace to store env variables in the $_ENV superglobal.
@@ -17,7 +71,7 @@
 
 		// Get root of user site folder
 		public static function root(string $crumbs = ""): string {
-			return $_ENV[Path::ENV_NS]["site_path"] . "/" . $crumbs;
+			return ENV::get("site_path") . "/" . $crumbs;
 		}
 
 		// List the files and folders in directory (without the dots on Linux)
@@ -26,18 +80,4 @@
 		}
 	}
 
-	// Load Composer dependencies
-	require_once Path::vegvisir(Path::COMPOSER_AUTOLOAD);
-
-	// Put environment variables from Vegvisir .ini into namespaced superglobal
-	$_ENV[Path::ENV_NS] = parse_ini_file(Path::vegvisir(Path::ENV_INI), true);
-
-	// Merge environment variables from user site into superglobal
-	if (file_exists(Path::root(Path::ENV_INI))) {
-		$_ENV = array_merge($_ENV, parse_ini_file(Path::root(Path::ENV_INI), true));
-	}
-
-	// Load composer dependencies from userspace if exists
-	if (file_exists(Path::root(Path::COMPOSER_AUTOLOAD))) {
-		require_once Path::root(Path::COMPOSER_AUTOLOAD);
-	}
+	ENV::init();

--- a/src/Init.php
+++ b/src/Init.php
@@ -9,7 +9,7 @@
 	class ENV {
         // Vegvisir environment variables are placed in $_ENV as an assoc array with this as the array key.
         // Example: $_ENV[self::NS][<vegvisir_env_var>]
-        private const NS = "_VEGVISIR";
+        public const NS = "_VEGVISIR";
 
 		// Name of the .ini file containing environment variables to be loaded (internal and userspace)
 		private const INI = ".env.ini";
@@ -48,22 +48,14 @@
 			}
 
 			// Load composer dependencies from userspace if exists
-			if (file_exists(Path::root(Path::COMPOSER_AUTOLOAD))) {
-				require_once Path::root(Path::COMPOSER_AUTOLOAD);
+			if (file_exists(Path::root(self::COMPOSER_AUTOLOAD))) {
+				require_once Path::root(self::COMPOSER_AUTOLOAD);
 			}
 		}
     }
 
 	// Global paths
 	class Path {
-		// Name of the environment variable files
-		const ENV_INI = ".env.ini";
-		// Namespace to store env variables in the $_ENV superglobal.
-		// Variables exported to JavaScript will also have this namespace on the globalThis
-		const ENV_NS = "_vegvisir";
-		// Path to composer autoload script
-		const COMPOSER_AUTOLOAD = "vendor/autoload.php";
-
 		// Get root of Vegvisir installation for accesing framework files
 		public static function vegvisir(string $crumbs = ""): string {
 			return dirname(__DIR__) . "/" . $crumbs;

--- a/src/frontend/bundle.php
+++ b/src/frontend/bundle.php
@@ -1,4 +1,16 @@
-<?php include Path::vegvisir("src/frontend/env.php"); ?>
+<?php 
+
+    /*
+        This file generates a minified bundle of all resources loaded with Path::init()
+        These are JavaScript files that are required to run the Vegvisir front-end.
+    */
+
+    use \Vegvisir\Path;
+
+    // Include export of select Vegvisir environment variables
+    include Path::vegvisir("src/frontend/env.php");
+
+?>
 <?= Page::js(Path::vegvisir("src/frontend/js/modules/Navigation.js"), false) ?>
 <?= Page::js(Path::vegvisir("src/frontend/js/modules/Interactions.js"), false) ?>
 <?= Page::js(Path::vegvisir("src/frontend/js/vegvisir.js"), false) ?>

--- a/src/frontend/env.php
+++ b/src/frontend/env.php
@@ -1,6 +1,8 @@
 <?php
 
-    // This procedural file exposes select variables from Path::ENV_NS to frontend in a globalThis variable.
+    // This procedural file exposes select variables from namespace to frontend in a globalThis variable.
+
+    use \Vegvisir\ENV;
 
     // Environment variables to expose to frontend
     $exports = [
@@ -10,9 +12,9 @@
     ];
 
     // Sequential array of strings with format 'VAR_NAME : "VAR_VALUE"'
-    $vars = array_map(fn($export): string => "${export}:\"{$_ENV[Path::ENV_NS][$export]}\"", $exports);
+    $vars = array_map(fn($export): string => "${export}:\"" . ENV::get($export) . "\"", $exports);
     // Turn vars into a CSV string
     $vars = implode(",", $vars);
 
     // Return generated JS
-    echo "globalThis." . Path::ENV_NS . " = {{$vars}};";
+    echo "globalThis." . ENV::get("NS") . " = {{$vars}};";

--- a/src/frontend/env.php
+++ b/src/frontend/env.php
@@ -16,5 +16,5 @@
     // Turn vars into a CSV string
     $vars = implode(",", $vars);
 
-    // Return generated JS
-    echo "globalThis." . ENV::get("NS") . " = {{$vars}};";
+    // Put environment varibles as object on globalThis
+    echo "globalThis." . strtolower(ENV::NS) . " = {{$vars}};";

--- a/src/frontend/js/modules/Interactions.js
+++ b/src/frontend/js/modules/Interactions.js
@@ -1,6 +1,5 @@
 // Event binder and handler for interactive elements
 class Interactions {
-
 	// Default options object used when constructing this class
 	static options = {
 		autoBind: true,

--- a/src/request/Page.php
+++ b/src/request/Page.php
@@ -1,5 +1,14 @@
 <?php
 
+	/*
+		NOTE: This file intentionally lacks a namespace
+		This is to make asset imports with "Page" less verbose in userspace
+		with no need to declare "use" on every page.
+	*/
+
+	use \Vegvisir\ENV;
+	use \Vegvisir\Path;
+
 	// Library used to minify JS and CSS
 	use MatthiasMullie\Minify;
 
@@ -13,7 +22,7 @@
 		public function __construct(string $page = null) {
 			// Return specific page if the Vegvisir "nav header" is detected, else return the app shell which in turn
 			// should spin up a Navigation to the requested specific page.
-			$page = !empty($_SERVER[$this::VEGVISIR_NAV_HEADER]) ? $page : $_ENV[Path::ENV_NS]["page_document"];
+			$page = !empty($_SERVER[$this::VEGVISIR_NAV_HEADER]) ? $page : ENV::get("page_document");
 
 			// Return the requested page
 			$this::include($page);
@@ -24,18 +33,18 @@
 			http_response_code($code);
 
 			// No custom error page is defined, just exit here
-			if (!in_array("error_page_path", array_keys($_ENV[Path::ENV_NS]))) {
+			if (!in_array("error_page_path", array_keys(ENV::get("NS")))) {
 				exit();
 			}
 			
 			// Put error code into environment variable so the custom error page can access it if desired
-			$_ENV[Path::ENV_NS][Page::HTTP_ERROR] = $code;
+			ENV::set(Page::HTTP_ERROR, $code);
 
 			include Path::root(
 				// Append .php extension if omitted
-				substr($_ENV[Path::ENV_NS]["error_page_path"], -4) === ".php" 
-					? $_ENV[Path::ENV_NS]["error_page_path"]
-					: $_ENV[Path::ENV_NS]["error_page_path"] . ".php"
+				substr(ENV::get("error_page_path"), -4) === ".php" 
+					? ENV::get("error_page_path")
+					: ENV::get("error_page_path") . ".php"
 			);
 		}
 
@@ -106,7 +115,7 @@
 		// Include external PHP file from user site into the current document
 		public static function include(string $name) {
 			// Rewrite empty path and "/" to page_index
-			$name = !empty($name) && $name !== "/" ? $name : $_ENV[Path::ENV_NS]["page_index"];
+			$name = !empty($name) && $name !== "/" ? $name : ENV::get("page_index");
 
 			// Attempt to load from user content pages
 			$file = Path::root("pages/${name}.php");

--- a/src/request/Router.php
+++ b/src/request/Router.php
@@ -1,5 +1,11 @@
 <?php
 
+	namespace Vegvisir\Request;
+
+	use \Page;
+	use \Vegvisir\ENV;
+	use \Vegvisir\Path;
+
 	require_once Path::vegvisir("src/request/Page.php");
 
 	enum StaticPathRegex: string {
@@ -37,7 +43,7 @@
 
 		private function get_requested_path(): string {
 			// Requests to root of user content path should be rewritten to configured index page
-			$path = $this->path !== "/" ? $this->path : $_ENV[Path::ENV_NS]["page_index"];
+			$path = $this->path !== "/" ? $this->path : ENV::get("page_index");
 
 			// Strip leading slash
 			if (strpos($this->path, "/") === 0) {


### PR DESCRIPTION
All classes etc. are now namespaced under `Vegvisir/*` **except** for `/src/request/Page.php` since things put in this class should immediately be available to any page PHP. It's unnecessarily verbose to have to type `use \Vegvisir\Page;` on every single page that needs to import assets