### PR TITLE
Carry POST parameters to page flag and default on initial load

### DIFF
--- a/src/frontend/bundle.php
+++ b/src/frontend/bundle.php
@@ -5,10 +5,15 @@
         These are JavaScript files that are required to run the Vegvisir front-end.
     */
 
+    use \Vegvisir\ENV;
     use \Vegvisir\Path;
+    use \Vegvisir\Frontend\ExportVariables;
 
     // Include export of select Vegvisir environment variables
     include Path::vegvisir("src/frontend/env.php");
+
+    // Expose exported variables on globalThis as a JavaScript object
+    echo "globalThis." . strtolower(ENV::NS) . " = " . (new ExportVariables())->json() . ";";
 
 ?>
 <?= Page::js(Path::vegvisir("src/frontend/js/modules/Navigation.js"), false) ?>

--- a/src/frontend/env.php
+++ b/src/frontend/env.php
@@ -19,28 +19,19 @@
 
         public function __construct() {
             // Resolve environment variables from constant and append to export array
-            $this->append_vars(array_combine(self::ENV, array_map(
+            $this->vars = array_combine(self::ENV, array_map(
                 fn(string $key): string => ENV::get($key), 
                 self::ENV)
-            ));
+            );
 
             // Expose initial request method as string. This is used on initial load to pass along the request method to 
-            $this->append_vars(["initial_method" => $_SERVER["REQUEST_METHOD"]]);
-
+            $this->vars["initial_method"] = $_SERVER["REQUEST_METHOD"];
             // Append POST data as stringified JSON to export array
-            $this->append_vars(["post_data" => htmlspecialchars(json_encode($_POST))]);
-        }
-
-        private function append_vars(array $vars) {
-            $this->vars = array_merge($this->vars, array_map(
-                fn(string $k, string $v): string => "{$k}:\"{$v}\"",
-                array_keys($vars),
-                array_values($vars)
-            ));
+            $this->vars["post_data"] = json_encode($_POST);
         }
 
         // Get JSON from $this->vars
         public function json() {
-            return "{" . implode(",", $this->vars) . "}";
+            return json_encode($this->vars);
         }
     }

--- a/src/frontend/env.php
+++ b/src/frontend/env.php
@@ -2,19 +2,45 @@
 
     // This procedural file exposes select variables from namespace to frontend in a globalThis variable.
 
+    namespace Vegvisir\Frontend;
+
     use \Vegvisir\ENV;
 
-    // Environment variables to expose to frontend
-    $exports = [
-        "selector_main_element",
-        "page_document",
-        "page_index"
-    ];
+    class ExportVariables {
+        // Sequential array of JSON formatted strings with property name and values
+        private array $vars = [];
 
-    // Sequential array of strings with format 'VAR_NAME : "VAR_VALUE"'
-    $vars = array_map(fn($export): string => "${export}:\"" . ENV::get($export) . "\"", $exports);
-    // Turn vars into a CSV string
-    $vars = implode(",", $vars);
+        // Export these variables from $_ENV
+        private const ENV = [
+            "selector_main_element",
+            "page_document",
+            "page_index"
+        ];
 
-    // Put environment varibles as object on globalThis
-    echo "globalThis." . strtolower(ENV::NS) . " = {{$vars}};";
+        public function __construct() {
+            // Resolve environment variables from constant and append to export array
+            $this->append_vars(array_combine(self::ENV, array_map(
+                fn(string $key): string => ENV::get($key), 
+                self::ENV)
+            ));
+
+            // Expose initial request method as string. This is used on initial load to pass along the request method to 
+            $this->append_vars(["initial_method" => $_SERVER["REQUEST_METHOD"]]);
+
+            // Append POST data as stringified JSON to export array
+            $this->append_vars(["post_data" => htmlspecialchars(json_encode($_POST))]);
+        }
+
+        private function append_vars(array $vars) {
+            $this->vars = array_merge($this->vars, array_map(
+                fn(string $k, string $v): string => "{$k}:\"{$v}\"",
+                array_keys($vars),
+                array_values($vars)
+            ));
+        }
+
+        // Get JSON from $this->vars
+        public function json() {
+            return "{" . implode(",", $this->vars) . "}";
+        }
+    }

--- a/src/frontend/js/modules/Navigation.js
+++ b/src/frontend/js/modules/Navigation.js
@@ -200,8 +200,6 @@ class Navigation {
 			target = document.querySelector(target);
 		}
 
-		console.log(globalThis._vegvisir);
-
 		// Fetch page and pass options and exposed environment variables
 		this.worker.postMessage({
 			options: this.options,

--- a/src/frontend/js/vegvisir.js
+++ b/src/frontend/js/vegvisir.js
@@ -12,7 +12,9 @@ globalThis.vegvisir = {
 // Fetch requested page on initial load
 globalThis.vegvisir.Navigation(window.location.pathname.length > 1 ? window.location.pathname : globalThis._vegvisir.page_index, {
 	// We want search parameters on initial load to be passed to requested page
-	carrySearchParams: true
+	carrySearchParams: true,
+	// We also want the page loaded to receive POST parameters etc.
+	carryRequestMethod: true
 })
 // Navigate the root element defined in Vegvisir env file
 .navigate(document.querySelector(globalThis._vegvisir.selector_main_element));

--- a/src/frontend/js/workers/NavigationWorker.js
+++ b/src/frontend/js/workers/NavigationWorker.js
@@ -10,9 +10,12 @@ class NavigationWorker {
 		// Append request method if carryRequestMethod flag is set
 		if (request.options.carryRequestMethod) {
 			this.options.method = request.vars.initial_method;
-			this.options.body = request.vars.post_data;
 
-			// TODO: Content type
+			// Append JSON request body if request is not GET or HEAD
+			if (!["GET", "HEAD"].includes(request.vars.initial_method.toUpperCase())) {
+				this.options.body = request.vars.post_data;
+				this.options.headers["Content-Type"] = "application/json";
+			}
 		}
 
 		this.getPage(request.url);

--- a/src/frontend/js/workers/NavigationWorker.js
+++ b/src/frontend/js/workers/NavigationWorker.js
@@ -1,10 +1,24 @@
 class NavigationWorker {
-	constructor(event) {
-		this.event = event;
+	constructor(request) {
+		this.options = {
+			// Tell the backend we only want page content, no app shell
+			headers: {
+				"X-Vegvisir-Navigation": true
+			}
+		};
 
-		this.getPage();	
+		// Append request method if carryRequestMethod flag is set
+		if (request.options.carryRequestMethod) {
+			this.options.method = request.vars.initial_method;
+			this.options.body = request.vars.post_data;
+
+			// TODO: Content type
+		}
+
+		this.getPage(request.url);
 	}
 
+	// Send response back to initator thread
 	async send(response) {
 		return response instanceof Response 
 			// Return page as plaintext along with the response HTTP status and the fetched URL
@@ -14,18 +28,11 @@ class NavigationWorker {
 	}
 
 	// Request page from back-end
-	async getPage() {
-		await this.send(
-			await fetch(new Request(this.event.data, {
-				headers: {
-					// Tell the backend we only want page content, no app shell
-					"X-Vegvisir-Navigation": true
-				}
-			}))
-		);
-
+	async getPage(url) {
+		// Fetch page from URL with options
+		await this.send(await fetch(new Request(url, this.options)));
 		globalThis.close();
 	}
 }
 
-globalThis.addEventListener("message", event => new NavigationWorker(event));
+globalThis.addEventListener("message", event => new NavigationWorker(event.data));

--- a/src/request/Page.php
+++ b/src/request/Page.php
@@ -60,13 +60,13 @@
 			}
 
 			// Attempt to read asset from user site first
-			$path = Path::root("assets/${folder}/${file}");
+			$path = Path::root("assets/{$folder}/{$file}");
 			if (is_file($path)) {
 				return $path;
 			}
 
 			// Default to framework static asset if no user site asset found
-			return Path::vegvisir("src/frontend/${folder}/${file}");
+			return Path::vegvisir("src/frontend/{$folder}/{$file}");
 		}
 
 		// These functions are exposed to all pages. They can be called
@@ -118,7 +118,7 @@
 			$name = !empty($name) && $name !== "/" ? $name : ENV::get("page_index");
 
 			// Attempt to load from user content pages
-			$file = Path::root("pages/${name}.php");
+			$file = Path::root("pages/{$name}.php");
 
 			if (!is_file($file)) {
 				return Page::error(404);

--- a/src/request/Router.php
+++ b/src/request/Router.php
@@ -20,6 +20,8 @@
 			// Get pathname from request URI
 			$this->path = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
 
+			if ($_SERVER["REQUEST_METHOD"])
+
 			// Perform request routing
 			switch ($this->path) {
 				// Get static asset from user content
@@ -42,6 +44,11 @@
 					return new Page($this->get_requested_path());
 			}
 		}
+
+		// Polyfill for loading parameters from a JSON request body into $_POST
+        private static function load_json_payload() {
+            return $_POST = json_decode(file_get_contents("php://input"), true) ?? [];
+        }
 
 		private function get_requested_path(): string {
 			// Requests to root of user content path should be rewritten to configured index page

--- a/src/request/Router.php
+++ b/src/request/Router.php
@@ -20,7 +20,10 @@
 			// Get pathname from request URI
 			$this->path = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
 
-			if ($_SERVER["REQUEST_METHOD"])
+			// Request has a body, attempt to parse it into $_POST
+			if (in_array("HTTP_CONTENT_TYPE", array_keys($_SERVER))) {
+				$this->parse_request_body();
+			}
 
 			// Perform request routing
 			switch ($this->path) {
@@ -45,10 +48,13 @@
 			}
 		}
 
-		// Polyfill for loading parameters from a JSON request body into $_POST
-        private static function load_json_payload() {
-            return $_POST = json_decode(file_get_contents("php://input"), true) ?? [];
-        }
+		// Parse request body into $_POST superglobal
+		private static function parse_request_body() {
+			// Polyfill for loading JSON from request body into $_POST
+			if ($_SERVER["HTTP_CONTENT_TYPE"] === "application/json") {
+				$_POST = json_decode(file_get_contents("php://input"), true) ?? [];
+			}
+		}
 
 		private function get_requested_path(): string {
 			// Requests to root of user content path should be rewritten to configured index page


### PR DESCRIPTION
This PR adds the option `carryRequestMethod` to `Navigation.options`. When set; this flag will carry both the initial request method received when `document.php` was loaded, and its request body to the `Page` loaded directly after the document.

This will expose POST parameters sent to a [new] session to the page receiving the initial request. Parameters are available under the standard `$_POST` PHP superglobal.