### PR TITLE
Better `.env.example.ini` comments

### DIFF
--- a/.env.example.ini
+++ b/.env.example.ini
@@ -1,37 +1,37 @@
-; ------------------------------------------------
-; # Your website
-; Absolute path to the root of your site contents.
-; ------------------------------------------------
+# ------------------------------------------------
+# # Your website
+# Absolute path to the root of your site contents.
+# ------------------------------------------------
 
 site_path = ""
 
-; -----------------
-; # Fontend set-up
-; -----------------
+# -----------------
+# # Fontend set-up
+# -----------------
 
-; ## Root element selector
-; The CSS selector of root element which the main page is contained in.
-; See X for more information about the Vegvisir root element.
+# ## Root element selector
+# The CSS selector of root element which the main page is contained in.
+# See X for more information about the Vegvisir root element.
 
 selector_main_element = "main"
 
-; ## Document page
-; Relative file name from "pages/" of the page to should be used as app shell
+# ## Document page
+# Relative file name from "pages/" of the page to should be used as app shell
 
 page_document = "document"
 
-; ## Landingpage
-; Relative file name from "pages/" of the page that should be loaded when no path provided (landingpage)
+# ## Landingpage
+# Relative file name from "pages/" of the page that should be loaded when no path provided (landingpage)
 
 page_index = "index"
 
-; ---------------------------------------------------------
-; # Optional features
-; Uncomment lines to enable and configure optional features
-; ---------------------------------------------------------
+# ---------------------------------------------------------
+# # Optional features
+# Uncomment ';' to enable and configure optional features
+# ---------------------------------------------------------
 
-; ## Custom error page
-; Relative path (from your "site_path") to a page to load on 4xx-5xx HTTP response codes
-; https://github.com/VictorWesterlund/vegvisir/wiki/Optional-features#custom-error-page
+# ## Custom error page
+# Relative path (from your "site_path") to a page to load on 4xx-5xx HTTP response codes
+# https://github.com/VictorWesterlund/vegvisir/wiki/Optional-features#custom-error-page
 
 ;error_page_path = ""


### PR DESCRIPTION
This PR replaces `;` used for comments about a particular section or setting with `#`.

`;` Works better for variables that should have full syntax highlighting even when "commented-out".
`#` Works better for actual comments. No syntax highlighting of variables etc.