### PR TITLE
Add `data-noscope` attribute for imported scripts

### DIFF
--- a/src/frontend/js/modules/Navigation.js
+++ b/src/frontend/js/modules/Navigation.js
@@ -92,7 +92,8 @@ class Navigation {
 				tag.setAttribute(attribute, script.getAttribute(attribute));
 			}
 			
-			tag.innerHTML = `{${script.innerText}}`;
+			// Scope imported JS by default unless the data-noscope is explicitly defined
+			tag.innerHTML = !"noscope" in tag.dataset ? `{${script.innerText}}` : script.innerHTML;
 
 			script.remove();
 			target.appendChild(tag);


### PR DESCRIPTION
JavaScript imported with `Page::JS()` will be scoped by default between `{}`. This behavior can now be overridden by setting the `data-noscope` attribute on a bounding `<script>` tag.

## Defaut

```php
<script><?= Page::js("script") ?></script>
```
```html
<script>{console.log("Some JS");}</script>
```

## With the `data-noscope` attribute

```php
<script data-noscope><?= Page::js("script") ?></script>
```
```html
<script>console.log("Some JS");</script>
```