### PR TITLE
Fix `data-noscope` issue causing all tags to output global scoped JS

### DIFF
--- a/src/frontend/js/modules/Navigation.js
+++ b/src/frontend/js/modules/Navigation.js
@@ -93,7 +93,7 @@ class Navigation {
 			}
 			
 			// Scope imported JS by default unless the data-noscope is explicitly defined
-			tag.innerHTML = !"noscope" in tag.dataset ? `{${script.innerText}}` : script.innerHTML;
+			tag.innerHTML = !("noscope" in script.dataset) ? `{${script.innerText}}` : script.innerHTML;
 
 			script.remove();
 			target.appendChild(tag);


### PR DESCRIPTION
This PR fixes a bug with the `data-noscope` attribute for `<script>` tags introduced in the last release. All script tags using the Vegvisir front-end would render scripts without default scoping regardless if `data-noscope` was present or not, causing a lot of issues.