### PR TITLE
Create URL object from string in nav worker

### DIFF
--- a/src/frontend/js/workers/NavigationWorker.js
+++ b/src/frontend/js/workers/NavigationWorker.js
@@ -18,7 +18,7 @@ class NavigationWorker {
 			}
 		}
 
-		this.getPage(request.url);
+		this.getPage(new URL(request.url));
 	}
 
 	// Send response back to initator thread
@@ -33,7 +33,7 @@ class NavigationWorker {
 	// Request page from back-end
 	async getPage(url) {
 		// Fetch page from URL with options
-		await this.send(await fetch(new Request(url, this.options)));
+		await this.send(await fetch(new Request(url.pathname, this.options)));
 		globalThis.close();
 	}
 }

--- a/src/frontend/js/workers/NavigationWorker.js
+++ b/src/frontend/js/workers/NavigationWorker.js
@@ -1,6 +1,11 @@
 class NavigationWorker {
 	constructor(request) {
-		this.options = {
+		// Parse URL form string into URL object
+		this.url = new URL(request.url);
+		// Expose request options as property
+		this.options = request.options;
+
+		this.fetchOptions = {
 			// Tell the backend we only want page content, no app shell
 			headers: {
 				"X-Vegvisir-Navigation": true
@@ -8,17 +13,17 @@ class NavigationWorker {
 		};
 
 		// Append request method if carryRequestMethod flag is set
-		if (request.options.carryRequestMethod) {
+		if (this.options.carryRequestMethod) {
 			this.options.method = request.vars.initial_method;
 
 			// Append JSON request body if request is not GET or HEAD
 			if (!["GET", "HEAD"].includes(request.vars.initial_method.toUpperCase())) {
-				this.options.body = request.vars.post_data;
-				this.options.headers["Content-Type"] = "application/json";
+				this.fetchOptions.body = request.vars.post_data;
+				this.fetchOptions.headers["Content-Type"] = "application/json";
 			}
 		}
 
-		this.getPage(new URL(request.url));
+		this.getPage();
 	}
 
 	// Send response back to initator thread
@@ -31,9 +36,17 @@ class NavigationWorker {
 	}
 
 	// Request page from back-end
-	async getPage(url) {
+	async getPage() {
+		// Fetch URL by pathname and carry search parameters
+		let url = this.url.pathname;
+
+		// Carry search parameters if flag is set
+		if (this.options.carrySearchParams) {
+			url = url + this.url.search;
+		}
+		
 		// Fetch page from URL with options
-		await this.send(await fetch(new Request(url.pathname, this.options)));
+		await this.send(await fetch(new Request(url, this.fetchOptions)));
 		globalThis.close();
 	}
 }


### PR DESCRIPTION
A string passed to `vegvisir.Navigation()` will be parsed into a URL object for pre-processing. It's then stringified with `URL.toString()` before being sent to the `NavigationWorker` script. On the other end, the string is passed directly to `fetch()`. With this PR, the URL gets re-parsed into an `URL` object on the worker-side so pre-processing can occur there as well.

# One such pre-processing event will be introduced with this PR
It is now possible to pass a fully-qualified URL to `Navigation()` and the page will still load as if a relative path was passed