### PR TITLE
Add option to proxy superglobal variables on pages loaded using `VV::include()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "matthiasmullie/minify": "^1.3"
+        "matthiasmullie/minify": "^1.3",
+        "victorwesterlund/globalsnapshot": "^1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e7806260d775937d439159cde5165225",
+    "content-hash": "0e8dae49bf51e77403ccc828b7c32f0d",
     "packages": [
         {
             "name": "matthiasmullie/minify",
-            "version": "1.3.69",
+            "version": "1.3.73",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matthiasmullie/minify.git",
-                "reference": "a61c949cccd086808063611ef9698eabe42ef22f"
+                "reference": "cb7a9297b4ab070909cefade30ee95054d4ae87a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matthiasmullie/minify/zipball/a61c949cccd086808063611ef9698eabe42ef22f",
-                "reference": "a61c949cccd086808063611ef9698eabe42ef22f",
+                "url": "https://api.github.com/repos/matthiasmullie/minify/zipball/cb7a9297b4ab070909cefade30ee95054d4ae87a",
+                "reference": "cb7a9297b4ab070909cefade30ee95054d4ae87a",
                 "shasum": ""
             },
             "require": {
@@ -26,9 +26,10 @@
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.0",
-                "matthiasmullie/scrapbook": "dev-master",
-                "phpunit/phpunit": ">=4.8"
+                "friendsofphp/php-cs-fixer": ">=2.0",
+                "matthiasmullie/scrapbook": ">=1.3",
+                "phpunit/phpunit": ">=4.8",
+                "squizlabs/php_codesniffer": ">=3.0"
             },
             "suggest": {
                 "psr/cache-implementation": "Cache implementation to use with Minify::cache"
@@ -51,12 +52,12 @@
                 {
                     "name": "Matthias Mullie",
                     "email": "minify@mullie.eu",
-                    "homepage": "http://www.mullie.eu",
+                    "homepage": "https://www.mullie.eu",
                     "role": "Developer"
                 }
             ],
             "description": "CSS & JavaScript minifier, in PHP. Removes whitespace, strips comments, combines files (incl. @import statements and small assets in CSS files), and optimizes/shortens a few common programming patterns.",
-            "homepage": "http://www.minifier.org",
+            "homepage": "https://github.com/matthiasmullie/minify",
             "keywords": [
                 "JS",
                 "css",
@@ -66,7 +67,7 @@
             ],
             "support": {
                 "issues": "https://github.com/matthiasmullie/minify/issues",
-                "source": "https://github.com/matthiasmullie/minify/tree/1.3.69"
+                "source": "https://github.com/matthiasmullie/minify/tree/1.3.73"
             },
             "funding": [
                 {
@@ -74,7 +75,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-01T09:00:18+00:00"
+            "time": "2024-03-15T10:27:10+00:00"
         },
         {
             "name": "matthiasmullie/path-converter",
@@ -128,6 +129,43 @@
                 "source": "https://github.com/matthiasmullie/path-converter/tree/1.1.3"
             },
             "time": "2019-02-05T23:41:09+00:00"
+        },
+        {
+            "name": "victorwesterlund/globalsnapshot",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/VictorWesterlund/php-globalsnapshot.git",
+                "reference": "80cb5d17b2f6228e174edb0853b2c39c5d6dac21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/VictorWesterlund/php-globalsnapshot/zipball/80cb5d17b2f6228e174edb0853b2c39c5d6dac21",
+                "reference": "80cb5d17b2f6228e174edb0853b2c39c5d6dac21",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "victorwesterlund\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Unlicense"
+            ],
+            "authors": [
+                {
+                    "name": "Victor Westerlund",
+                    "email": "victor.vesterlund@gmail.com"
+                }
+            ],
+            "description": "Capture and restore the state of all PHP superglobals.",
+            "support": {
+                "issues": "https://github.com/VictorWesterlund/php-globalsnapshot/issues",
+                "source": "https://github.com/VictorWesterlund/php-globalsnapshot/tree/1.0.2"
+            },
+            "time": "2024-04-19T09:43:51+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/request/Proxy.php
+++ b/src/request/Proxy.php
@@ -1,0 +1,62 @@
+<?php
+
+	namespace Vegvisir\Request;
+
+	// Library for storing and restoring superglobal variables
+	use victorwesterlund\GlobalSnapshot;
+
+	// Create a new include proxy for holding existing PHP superglobal variables before a VV::include()
+	// This can be used to send mock superglobal variables to another page and then restore them after it has been included
+	class Proxy extends GlobalSnapshot {
+		public function __construct() {
+			parent::__construct();
+
+			$this->capture();
+		}
+
+		public function env(array $vars): self {
+			$_ENV = $vars;
+			return $this;
+		}
+
+		public function get(array $vars): self {
+			$_GET = $vars;
+			return $this;
+		}
+
+		public function post(array $vars): self {
+			$_POST = $vars;
+			return $this;
+		}
+
+		public function files(array $vars): self {
+			$_FILES = $vars;
+			return $this;
+		}
+
+		public function server(array $vars): self {
+			$_SERVER = $vars;
+			return $this;
+		}
+
+		public function cookie(array $vars): self {
+			$_COOKIE = $vars;
+			return $this;
+		}
+
+		public function request(array $vars): self {
+			$_REQUEST = $vars;
+			return $this;
+		}
+
+		public function session(array $vars): self {
+			$_SESSION = $vars;
+			return $this;
+		}
+
+		// ----
+
+		public function proxy(): void {
+			$this->restore();
+		}
+	}

--- a/src/request/VV.php
+++ b/src/request/VV.php
@@ -111,7 +111,7 @@
 		}
 
 		// Include external PHP file from user site into the current document
-		public static function include(string $name, array $get = null, array $post = null) {
+		public static function include(string $name) {
 			// Rewrite empty path and "/" to page_index
 			$name = !empty($name) && $name !== "/" ? $name : ENV::get(ENV::INDEX);
 

--- a/src/request/VV.php
+++ b/src/request/VV.php
@@ -11,8 +11,9 @@
 
 	// Library used to minify JS and CSS
 	use MatthiasMullie\Minify;
-	// Library for storing superglobal states
-	use victorwesterlund\GlobalSnapshot;
+
+	// -- Expose these helper scripts to Vegvisir pages --
+	require_once Path::vegvisir("src/request/Proxy.php");
 
 	class VV {
 		// This class will look for this header to determine if we should send the env "page_document" or
@@ -111,8 +112,6 @@
 
 		// Include external PHP file from user site into the current document
 		public static function include(string $name, array $get = null, array $post = null) {
-			$snapshot = new GlobalSnapshot();
-
 			// Rewrite empty path and "/" to page_index
 			$name = !empty($name) && $name !== "/" ? $name : ENV::get(ENV::INDEX);
 
@@ -123,29 +122,8 @@
 				return self::error(404);
 			}
 
-			// Proxy superglobals if defined
-			if ($get || $post) {
-				// Create a superglobal restore point
-				$snapshot->capture();
-
-				// Proxy GET superglobal
-				if ($get) {
-					$_GET = $get;
-				}
-
-				// Proxy POST superglobal
-				if ($post) {
-					$_POST = $post;
-				}
-			}
-
 			// Import and run PHP file
 			include $file;
-
-			// Restore captured superglobals
-			if ($snapshot->captured) {
-				$snapshot->restore();
-			}
 		}
 
 		public static function init(): void {


### PR DESCRIPTION
This PR adds support to "proxy" superglobal variables for pages imported with `VV::include()`.