### PR TITLE
Remove leading namespace slashes from `use` statements

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,7 +1,7 @@
 <?php
 
-	use \Vegvisir\Path;
-	use \Vegvisir\Request\Router;
+	use Vegvisir\Path;
+	use Vegvisir\Request\Router;
 
 	require_once "../src/Init.php";
 

--- a/src/Init.php
+++ b/src/Init.php
@@ -5,8 +5,8 @@
 	const PATH_COMPOSER = "vendor/autoload.php";
 	const PATH_ENV = ".env.ini";
 
-	use \Vegvisir\ENV;
-	use \Vegvisir\Path;
+	use Vegvisir\ENV;
+	use Vegvisir\Path;
 
 	// Backed enum for all variables available in ENV::ENV_INI
 	enum ENV: string {

--- a/src/frontend/bundle.php
+++ b/src/frontend/bundle.php
@@ -6,9 +6,9 @@
 		are required for Vegvisir SPA functions.
 	*/
 
-	use \Vegvisir\ENV;
-	use \Vegvisir\Path;
-	use \Vegvisir\Frontend\ExportVariables;
+	use Vegvisir\ENV;
+	use Vegvisir\Path;
+	use Vegvisir\Frontend\ExportVariables;
 
 	// Include export of select Vegvisir environment variables
 	include Path::vegvisir("src/frontend/env.php");

--- a/src/frontend/env.php
+++ b/src/frontend/env.php
@@ -4,7 +4,7 @@
 
 	namespace Vegvisir\Frontend;
 
-	use \Vegvisir\ENV;
+	use Vegvisir\ENV;
 
 	class ExportVariables {
 		// Sequential array of JSON formatted strings with property name and values

--- a/src/request/VV.php
+++ b/src/request/VV.php
@@ -6,8 +6,8 @@
 		with no need to declare "use" on every page.
 	*/
 
-	use \Vegvisir\ENV;
-	use \Vegvisir\Path;
+	use Vegvisir\ENV;
+	use Vegvisir\Path;
 
 	// Library used to minify JS and CSS
 	use MatthiasMullie\Minify;


### PR DESCRIPTION
Not required, looks ugly, and adds a few extra unnecessary bytes.