### PR TITLE
Add linefeeds for frontend bundler to fix comment overlap bug

### DIFF
--- a/src/frontend/bundle.php
+++ b/src/frontend/bundle.php
@@ -18,11 +18,14 @@
 	// Vegvisir inline modules and initializer LibreJS reference.
 	"// @license magnet:?xt=urn:btih:3877d6d54b3accd4bc32f8a48bf32ebc0901502a&dn=mpl-2.0.txt MPL-2.0"
 ?>
+
 <?php // Vegvisir global property and public environment variables ?>
 <?= ";globalThis.vv = {};" ?>
 <?= "globalThis.vv._env = " . (new ExportVariables())->json() . ";" ?>
+
 <?php // Vegvisir initializer and global module scripts ?>
 <?= VV::js(Path::vegvisir("src/frontend/js/modules/Navigation.js"), false) . ";" ?>
 <?= VV::js(Path::vegvisir("src/frontend/js/modules/Interactions.js"), false) . ";" ?>
 <?= VV::js(Path::vegvisir("src/frontend/js/vegvisir.js"), false) ?>
+
 <?= "// @license-end" ?>


### PR DESCRIPTION
This PR fixes a critical bug introduced in 40eb676dabde5c171db7632a2a99c727111e541b where the first line which initializes the `vv` global was treated as a comment due to the license header lacking a line feed.