### PR TITLE
Always "carry search parameters" when a URL is received to navigation worker

### DIFF
--- a/src/frontend/js/workers/Navigate.js
+++ b/src/frontend/js/workers/Navigate.js
@@ -39,16 +39,8 @@ class Navigate {
 
 	// Request page from back-end
 	async getPage() {
-		// Fetch URL by pathname and carry search parameters
-		let url = this.url.pathname;
-
-		// Carry search parameters if flag is set
-		if (this.options.carrySearchParams) {
-			url = url + this.url.search;
-		}
-		
-		// Fetch page from URL with options
-		await this.send(await fetch(new Request(url, this.fetchOptions)));
+		// Fetch page by pathname and search params from URL with options
+		await this.send(await fetch(new Request(this.url.pathname + this.url.search, this.fetchOptions)));
 		globalThis.close();
 	}
 }


### PR DESCRIPTION
This PR fixes a bug where search parameters are not carried to the requested page even if parameters have been explicitly defined.

Example:
```js
new vv.Navigation("page?foo=bar")
```
Would not carry "?foo=bar" even though it has been intentionally set. the `carrySearchParams` option had to be set to `true` in order for the params to be sent to the requested page.

This PR makes it so `carrySearchParams` is only supposed to be set if the page is supposed to have the **top** page params carried to the requested page. Which is the intended behavior.