### PR TITLE
Add loading attribute to navigation target

### DIFF
--- a/src/frontend/js/modules/Navigation.js
+++ b/src/frontend/js/modules/Navigation.js
@@ -223,12 +223,12 @@ globalThis.vv.Navigation = class Navigation {
 				// Get navigation details from Worker
 				const [body, status, finalUrl] = event.data;
 
+				// Unset loading attribute on target
+				target.setAttribute("vv-loading", false);
+
 				// Update DOM and resolve this and outer Promise
 				this.setTargetHtml(target, body);
 				this.dispatchEvent(Navigation.events.LOADED, target);
-
-				// Unset loading attribute on target
-				target.setAttribute("vv-loading", false);
 
 				// Navigation target is the main element
 				if (target === this.main) {

--- a/src/frontend/js/modules/Navigation.js
+++ b/src/frontend/js/modules/Navigation.js
@@ -205,6 +205,11 @@ globalThis.vv.Navigation = class Navigation {
 			target = document.querySelector(target);
 		}
 
+		// Set loading attribute on target
+		target.setAttribute("vv-loading", true);
+		// Set upcoming page pathname on target element
+		target.setAttribute("vv-page", url.pathname);
+
 		// Fetch page and pass options and exposed environment variables
 		this.worker.postMessage({
 			options: this.options,
@@ -222,8 +227,8 @@ globalThis.vv.Navigation = class Navigation {
 				this.setTargetHtml(target, body);
 				this.dispatchEvent(Navigation.events.LOADED, target);
 
-				// Set loaded page pathname on target element
-				target.setAttribute("vv-page", url.pathname);
+				// Unset loading attribute on target
+				target.setAttribute("vv-loading", false);
 
 				// Navigation target is the main element
 				if (target === this.main) {


### PR DESCRIPTION
This PR adds a new Vegvisir navigation attribute `vv-loading` which will be set on a `vv.Navigation` target when `.navigate()` starts.

The value of this string boolean attribute will be `"true"` until the navigation worker has responded with the loaded page, and when the page content has been appended to the target DOM - after which it will be set to `"false"`.

----

This PR also sets the `vv-page` attribute immediately when `.navigate()` starts, and doesn't wait for the page to load.