### PR TITLE
`VV::include` pages anywhere relative from userspace

### DIFF
--- a/src/request/VV.php
+++ b/src/request/VV.php
@@ -26,7 +26,12 @@
 			$page = !empty($_SERVER[self::VEGVISIR_NAV_HEADER]) ? $page : ENV::get(ENV::DOCUMENT);
 
 			// Return the requested page
-			self::include($page);
+			self::include("pages/{$page}.php");
+		}
+
+		// Append extension string to input string if omitted
+		private static function append_extension(string $input, string $extension): string {
+			return strpos($input, $extension) ? $input : $input . $extension;
 		}
 
 		// Set HTTP response code and return error page if enabled
@@ -38,91 +43,45 @@
 				exit();
 			}
 
-			include Path::root(
-				// Append .php extension if omitted
-				substr(ENV::get(ENV::ERROR_PAGE), -4) === ".php" 
-					? ENV::get(ENV::ERROR_PAGE)
-					: ENV::get(ENV::ERROR_PAGE) . ".php"
-			);
+			include Path::root(self::append_extension(ENV::get(ENV::ERROR_PAGE), ".php"));
 		}
 
-		// Return absolute path to asset on disk.
-		// The function takes a "scope" in the form of a $folder name relative to the asset root
-		// to prevent this function from reading anywhere on disk.
-		private static function get_asset_path(string $folder, string $file): string {
-			// Append name of folder as file extension if omitted.
-			// This may or may not resolve into an existing file. But for common web assets like
-			// JS and CSS it works rather fine.
-			if (strpos($file, ".") === false) {
-				$file .= "." . $folder;
-			}
-
-			// Attempt to read asset from user site first
-			$path = Path::root("assets/{$folder}/{$file}");
-			if (is_file($path)) {
-				return $path;
-			}
-
-			// Default to framework static asset if no user site asset found
-			return Path::vegvisir("src/frontend/{$folder}/{$file}");
-		}
-
-		// These functions are exposed to all pages. They can be called
-		// with the static reference self::<method> anywhere on the page.
-
-		// Return minified CSS from file
+		// Load and return minified CSS file from absolute path or CSS assets folder
 		public static function css(string $file, bool $relative = true): string {
-			// Get assets/css relative from site path unless the relative flag is set.
-			// An unset relative flag will make the path absolute.
-			$file = $relative ? self::get_asset_path("css", $file) : $file;
+			$file = $relative ? Path::root("assets/css/" . self::append_extension($file, ".css")) : $file;
 
 			// Import and minify CSS stylesheet or return empty string if not found
 			return is_file($file) ? (new Minify\CSS($file))->minify() : "";
 		}
 
-		// Return minified JS from file
+		// Load and return minified JS file from absolute path or JS assets folder
 		public static function js(string $file, bool $relative = true): string {
-			// Get assets/js relative from site path unless the relative flag is set.
-			// An unset relative flag will make the path absolute.
-			$file = $relative ? self::get_asset_path("js", $file) : $file;
+			$file = $relative ? Path::root("assets/js/" . self::append_extension($file, ".js")) : $file;
 
 			// Import and minify JS source or return empty string if not found
 			return is_file($file) ? (new Minify\JS($file))->minify() : "";
 		}
 
-		// Return contents of media file as base64-encoded string unless whitelisted
-		// for assets that should be read as-is, such as SVG.
+		// Load and return contents of a file from absolute path or media assets folder
 		public static function media(string $file, bool $relative = true): string {
-			// Get assets/media relative from site path unless the relative flag is set.
-			// An unset relative flag will make the path absolute.
-			$file = $relative ? file_get_contents(self::get_asset_path("media", $file)) : $file;
-
-			// Invalid file returns empty string
-			if ($file === false) {
-				return "";
-			}
-
-			// Base64-encode everything that isn't in whitelist array
-			if (!preg_match("//u", $file)) {
-				$file = base64_encode($file);
-			}
+			$file = $relative ? Path::root("assets/media/" . $file) : $file;
 			
-			return $file;
+			return is_file($file) ? file_get_contents($file) : "";
 		}
 
-		// Include external PHP file from user site into the current document
+		// Include and evaulate a PHP file relative from userspace root
 		public static function include(string $name) {
-			// Rewrite empty path and "/" to page_index
-			$name = !empty($name) && $name !== "/" ? $name : ENV::get(ENV::INDEX);
+			// Rewrite empty paths to index page
+			$name = !empty($name) && $name !== "pages/.php" ? $name : "pages/" . ENV::get(ENV::INDEX);
 
-			// Attempt to load from user content pages
-			$file = Path::root("pages/{$name}.php");
+			// Load PHP file relative from userpsace root
+			$file = Path::root(self::append_extension($name, ".php"));
 
 			if (!is_file($file)) {
 				return self::error(404);
 			}
 
-			// Import and run PHP file
+			// Import and evaluate PHP file
 			include $file;
 		}
 


### PR DESCRIPTION
This PR removes the restriction that pages included with `VV::include` have to be placed somewhere in `/pages` from the userspace project root. Pages can now be imported from anywhere relative to userspace root, this is helpful for including pages that should not be directly accessible.

For example
```php
VV::include("modules/module");
```

Should not be accessible from, which it now isn't
```
https://example.com/modules/module
```