### PR TITLE
Pass URL object directly to Request constructor

### DIFF
--- a/src/frontend/js/workers/Navigate.js
+++ b/src/frontend/js/workers/Navigate.js
@@ -40,7 +40,7 @@ class Navigate {
 	// Request page from back-end
 	async getPage() {
 		// Fetch page by pathname and search params from URL with options
-		await this.send(await fetch(new Request(this.url.pathname + this.url.search, this.fetchOptions)));
+		await this.send(await fetch(new Request(this.url, this.fetchOptions)));
 		globalThis.close();
 	}
 }


### PR DESCRIPTION
This PR removes the unnecessary string concatenation of `URL.pathname` + `URL.search` in the navigation worker. `Request` accepts a `URL` object as its first argument.