### PR TITLE
Add default "source" argument in `Navigation` to current URL

### DIFF
--- a/src/frontend/js/modules/Navigation.js
+++ b/src/frontend/js/modules/Navigation.js
@@ -20,7 +20,7 @@ globalThis.vv.Navigation = class Navigation {
 		carryRequestMethod: false
 	}
 
-	constructor(source, options = {}) {
+	constructor(source = window.location, options = {}) {
 		// Spin up dedicated worker
 		this.worker = new Worker(Navigation.WORKER_PATHNAME);
 


### PR DESCRIPTION
Passing nothing to `new vv.Navigation()` will default to the current page.

This makes it behave similarly to its `.navigate()` method which defaults to the page main selector if empty.

This can be used to quickly refresh a page with `Navgiation().navigate()` for example.