### PR TITLE
Return and log error for missing `Interactions` methods.

### DIFF
--- a/src/frontend/js/modules/Interactions.js
+++ b/src/frontend/js/modules/Interactions.js
@@ -40,6 +40,11 @@ globalThis.vv.Interactions = class Interactions {
 		element.addEventListener(this.options.eventType, (event) => {
 			event.preventDefault();
 			event.stopPropagation();
+
+			// Bail out if method does not exist in namespace
+			if (!(methodName in this.methods)) {
+				return console.error(`Vegvisir:Interactions: Method '${methodName}' not found`, this.methods);
+			}
 			
 			this.methods[methodName](event);
 		});


### PR DESCRIPTION
Return an error if an interaction calls for a method that does not exist in the provided `methods` object for a given `vv.Interactions` instance.