### PR TITLE
Change attribute name of `body[vv-page]` to `body[vv-top-page]`

### DIFF
--- a/src/frontend/js/modules/Navigation.js
+++ b/src/frontend/js/modules/Navigation.js
@@ -240,7 +240,7 @@ globalThis.vv.Navigation = class Navigation {
 				// Navigation target is the main element
 				if (target === this.main) {
 					// Set loaded page pathname on document body if main was navigated
-					document.body.setAttribute("vv-page", url.pathname);
+					document.body.setAttribute("vv-top-page", url.pathname);
 
 					// Add final URL to history and carry anchor from requested URL if provided
 					this.historyPush(finalUrl + url.hash);


### PR DESCRIPTION
This PR adds a different attribute name for the body element when a top navigation has occurred. This allows less verbose scoping in CSS and JS when dealing with more complex `vv.Navigation` contexts.